### PR TITLE
111619 nt hystrix and ribbon timeout

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+hystrix:
+  command:
+    default:
+      execution:
+        iso lation:
+          thread:
+            timeoutInMilliseconds: 30000
+
+ribbon:
+  ReadTimeout: 60000
+  connection-timeout: 3000
+  eureka:
+    enabled: true
+

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -1,11 +1,3 @@
-hystrix:
-  command:
-    default:
-      execution:
-        iso lation:
-          thread:
-            timeoutInMilliseconds: 30000
-
 ribbon:
   ReadTimeout: 60000
   connection-timeout: 3000


### PR DESCRIPTION
- add ribbon time out options on api-gateway
- tested locally, haven't seen a zuul readtimeout since.